### PR TITLE
Fix SFD mode and preamble for 6.8 Mbps low-power tests

### DIFF
--- a/notworking/sketch_ppk2_merged_power/sketch_ppk2_merged_power.ino
+++ b/notworking/sketch_ppk2_merged_power/sketch_ppk2_merged_power.ino
@@ -45,7 +45,7 @@ uint8_t configOption = 1;
 uint8_t channel = 1;
 uint8_t pulseFrequency = DW1000.TX_PULSE_FREQ_16MHZ;
 uint8_t dataRate = DW1000.TRX_RATE_6800KBPS;
-uint8_t preambleLength = DW1000.TX_PREAMBLE_LEN_128;
+uint8_t preambleLength = DW1000.TX_PREAMBLE_LEN_64;
 
 // ===== TEST STATE MANAGEMENT =====
 enum TestMode {
@@ -644,7 +644,7 @@ void initializeDirectMode() {
     DW1000.setChannel(channel);
     uint16_t antennaDelay = getAntennaDelayForChannel(channel);
     DW1000.setAntennaDelay(antennaDelay);
-    byte customMode[3] = { DW1000.TRX_RATE_6800KBPS, DW1000.TX_PULSE_FREQ_16MHZ, DW1000.TX_PREAMBLE_LEN_128 };
+    byte customMode[3] = { DW1000.TRX_RATE_6800KBPS, DW1000.TX_PULSE_FREQ_16MHZ, DW1000.TX_PREAMBLE_LEN_64 };
     DW1000.enableMode(customMode);
     DW1000.commitConfiguration();
     usingRangingLayer = false;

--- a/notworking/sketch_ppk2_tag_power/sketch_ppk2_tag_power.ino
+++ b/notworking/sketch_ppk2_tag_power/sketch_ppk2_tag_power.ino
@@ -45,11 +45,11 @@ U8G2_SH1106_128X64_NONAME_1_HW_I2C display(U8G2_R0, U8X8_PIN_NONE);  // page-buf
 uint8_t configOption = 0;  // Set this to select configuration mode (0-6)
 
 // Manual configuration settings (only used when configOption = 0)
-// UPDATED: Changed to 16MHz PRF, 6800kbps, 64 preamble
+// UPDATED: 16MHz PRF, 6800kbps, 64 preamble for low-power operation
 uint8_t manualChannel = 5;
 uint8_t manualPulseFrequency = DW1000.TX_PULSE_FREQ_16MHZ;
 uint8_t manualDataRate = DW1000.TRX_RATE_6800KBPS;
-uint8_t manualPreambleLength = DW1000.TX_PREAMBLE_LEN_128;
+uint8_t manualPreambleLength = DW1000.TX_PREAMBLE_LEN_64;
 
 // Variables that will hold the active configuration
 uint8_t channel;
@@ -138,7 +138,7 @@ void setup()
     // Preset configurations - UPDATED to 16MHz PRF, 6800kbps, 64 preamble
     pulseFrequency = DW1000.TX_PULSE_FREQ_16MHZ;
     dataRate = DW1000.TRX_RATE_6800KBPS;
-    preambleLength = DW1000.TX_PREAMBLE_LEN_128;
+    preambleLength = DW1000.TX_PREAMBLE_LEN_64;
     
     // Set channel based on preset selection
     switch (configOption) {
@@ -241,7 +241,7 @@ void applyNewConfiguration() {
     // Preset configurations - UPDATED to 16MHz PRF, 6800kbps, 64 preamble
     pulseFrequency = DW1000.TX_PULSE_FREQ_16MHZ;
     dataRate = DW1000.TRX_RATE_6800KBPS;
-    preambleLength = DW1000.TX_PREAMBLE_LEN_128;
+    preambleLength = DW1000.TX_PREAMBLE_LEN_64;
     
     // Set channel based on preset selection
     switch (configOption) {

--- a/src/DW1000.cpp
+++ b/src/DW1000.cpp
@@ -1149,19 +1149,22 @@ void DW1000Class::setDataRate(byte rate) {
 		setBit(_syscfg, LEN_SYS_CFG, RXM110K_BIT, false);
 	}
 	// SFD mode and type (non-configurable, as in Table )
-	if(rate == TRX_RATE_6800KBPS) {
-		setBit(_chanctrl, LEN_CHAN_CTRL, DWSFD_BIT, false);
-		setBit(_chanctrl, LEN_CHAN_CTRL, TNSSFD_BIT, false);
-		setBit(_chanctrl, LEN_CHAN_CTRL, RNSSFD_BIT, false);
-	} else if (rate == TRX_RATE_850KBPS) {
-		setBit(_chanctrl, LEN_CHAN_CTRL, DWSFD_BIT, true);
-		setBit(_chanctrl, LEN_CHAN_CTRL, TNSSFD_BIT, true);
-		setBit(_chanctrl, LEN_CHAN_CTRL, RNSSFD_BIT, true);
-	} else {
-		setBit(_chanctrl, LEN_CHAN_CTRL, DWSFD_BIT, true);
-		setBit(_chanctrl, LEN_CHAN_CTRL, TNSSFD_BIT, false);
-		setBit(_chanctrl, LEN_CHAN_CTRL, RNSSFD_BIT, false);
-	}
+        if(rate == TRX_RATE_6800KBPS) {
+                // 6.8 Mbps uses a non-standard 8-symbol SFD sequence.
+                // Both transmitter and receiver must enable the non-standard SFD
+                // bits so the user-defined sequence length applies on both ends.
+                setBit(_chanctrl, LEN_CHAN_CTRL, DWSFD_BIT, false);
+                setBit(_chanctrl, LEN_CHAN_CTRL, TNSSFD_BIT, true);
+                setBit(_chanctrl, LEN_CHAN_CTRL, RNSSFD_BIT, true);
+        } else if (rate == TRX_RATE_850KBPS) {
+                setBit(_chanctrl, LEN_CHAN_CTRL, DWSFD_BIT, true);
+                setBit(_chanctrl, LEN_CHAN_CTRL, TNSSFD_BIT, true);
+                setBit(_chanctrl, LEN_CHAN_CTRL, RNSSFD_BIT, true);
+        } else {
+                setBit(_chanctrl, LEN_CHAN_CTRL, DWSFD_BIT, true);
+                setBit(_chanctrl, LEN_CHAN_CTRL, TNSSFD_BIT, false);
+                setBit(_chanctrl, LEN_CHAN_CTRL, RNSSFD_BIT, false);
+        }
 	byte sfdLength;
 	if(rate == TRX_RATE_6800KBPS) {
 		sfdLength = 0x08;


### PR DESCRIPTION
## Summary
- Set DW1000 to use the non-standard 8-symbol SFD when configured for 6.8 Mbps.
- Align tag and anchor power-test sketches to use a matching 64-symbol preamble for low-power operation.

## Testing
- `arduino-cli --version` *(fails: command not found)*
- `apt-get update` *(fails: repository 403 Forbidden)*


------
https://chatgpt.com/codex/tasks/task_e_6897d805007c8329bd872fbe8f8e0b5a